### PR TITLE
Revert "update package.json"

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,17 +18,12 @@
   ],
   "author": "SubQuery Network",
   "license": "MIT",
-  "resolutions": {
-    "@polkadot/api": "^6.11.1",
-    "@polkadot/types": "^7.8.1",
-    "@polkadot/util": "^7.9.2"
-  },
   "devDependencies": {
-    "@polkadot/api": "^7.12.1",
+    "@polkadot/api": "^7",
     "@subql/types": "latest",
-    "typescript": "^4.4.4",
+    "typescript": "^4.1.3",
     "@subql/cli": "latest",
-    "moonbeam-types-bundle": "^2.0.3"
+    "moonbeam-types-bundle": "^2.0.2"
   },
   "exports": {
     "chaintypes": "src/chaintypes.ts"


### PR DESCRIPTION
Reverts subquery/moonriver-subql-starter#1


"resolutions": {
    "@polkadot/api": "^6.11.1",
    "@polkadot/types": "^7.8.1",
    "@polkadot/util": "^7.9.2"
  },

These resolutions will downgrade @polkadot/api to V6 